### PR TITLE
ObjectsTranslator: support reading FourCC codes lower than 2^24 (Crs)

### DIFF
--- a/src/W3Buffer.ts
+++ b/src/W3Buffer.ts
@@ -41,7 +41,7 @@ export class W3Buffer {
         }).join('');
     }
 
-    public readChars(len: number = 1): string {
+    public readChars(len: number = 1, allowNull: boolean = false): string {
         const string = [];
         const numCharsToRead = len || 1;
 
@@ -51,9 +51,13 @@ export class W3Buffer {
         }
 
         return string.map((ch) => {
-            if (ch === 0x0) return '0';
+            if (!allowNull && ch === 0x0) return '0';
             return String.fromCharCode(ch);
         }).join('');
+    }
+
+    public readFourCC(): string {
+        return this.readChars(4, true);
     }
 
     public readByte() {

--- a/src/translators/ObjectsTranslator.ts
+++ b/src/translators/ObjectsTranslator.ts
@@ -185,8 +185,8 @@ export abstract class ObjectsTranslator {
             for (let i = 0; i < numTableModifications; i++) {
                 const objectDefinition = []; // object definition will store one or more modification objects
 
-                const originalId = outBufferToJSON.readChars(4),
-                    customId = outBufferToJSON.readChars(4),
+                const originalId = outBufferToJSON.readFourCC(),
+                    customId = outBufferToJSON.readFourCC(),
                     modificationCount = outBufferToJSON.readInt();
 
                 for (let j = 0; j < modificationCount; j++) {
@@ -198,7 +198,7 @@ export abstract class ObjectsTranslator {
                         value: {}
                     };
 
-                    modification.id = outBufferToJSON.readChars(4);
+                    modification.id = outBufferToJSON.readFourCC();
                     modification.type = this.varTypes[outBufferToJSON.readInt()]; // 'int' | 'real' | 'unreal' | 'string',
 
                     if (type === ObjectType.Doodads || type === ObjectType.Abilities || type === ObjectType.Upgrades) {
@@ -217,7 +217,7 @@ export abstract class ObjectsTranslator {
                     if (isOriginalTable) {
                         outBufferToJSON.readInt(); // should be 0 for original objects
                     } else {
-                        outBufferToJSON.readChars(4); // should be object ID for custom objects
+                        outBufferToJSON.readFourCC(); // should be object ID for custom objects
                     }
 
                     objectDefinition.push(modification);


### PR DESCRIPTION
There are likely other places that would be more correct by using readFourCC(), but this fixes #78 