### PR TITLE
Fix incorrect path to package.json in CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import { program } from 'commander';
 import * as fs from 'fs-extra';
 import path from 'node:path';
-import { version } from '../package.json';
+import { version } from '../../package.json';
 import { JsonResult, WarResult, ITranslator, VersionError } from './CommonInterfaces';
 import { ObjectsTranslator } from './index';
 import translatorMappings from './TranslatorMappings';


### PR DESCRIPTION
Fixes the `MODULE_NOT_FOUND` error when running the CLI: `Cannot find module '../package.json'`. Changed the import path in TypeScript source to ensure correct resolution after compilation.