### PR TITLE
Fix published CLI runtime startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "chalk": "^5.6.2",
                 "commander": "^14.0.2",
+                "fs-extra": "^11.3.5",
                 "ieee754": "^1.2.1",
                 "intn": "^1.0.0",
                 "round-to": "^7.0.0"
@@ -26,7 +27,6 @@
                 "coveralls": "^3.1.0",
                 "eslint": "^9.39.2",
                 "eslint-plugin-github": "^6.0.0",
-                "fs-extra": "^11.3.3",
                 "source-map-support": "^0.5.19",
                 "ts-node": "^9.1.1",
                 "typescript": "^4.2.2",
@@ -2242,10 +2242,9 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-            "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-            "dev": true,
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -2434,7 +2433,6 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/har-schema": {
@@ -3150,7 +3148,6 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
             "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -4580,7 +4577,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "dependencies": {
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
+        "fs-extra": "^11.3.5",
         "ieee754": "^1.2.1",
         "intn": "^1.0.0",
         "round-to": "^7.0.0"
@@ -66,7 +67,6 @@
         "coveralls": "^3.1.0",
         "eslint": "^9.39.2",
         "eslint-plugin-github": "^6.0.0",
-        "fs-extra": "^11.3.3",
         "source-map-support": "^0.5.19",
         "ts-node": "^9.1.1",
         "typescript": "^4.2.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,11 +5,14 @@
 import chalk from 'chalk';
 import { program } from 'commander';
 import * as fs from 'fs-extra';
+import { createRequire } from 'node:module';
 import path from 'node:path';
-import { version } from '../package.json';
 import { JsonResult, WarResult, ITranslator, VersionError } from './CommonInterfaces';
 import { ObjectsTranslator } from './index';
 import translatorMappings from './TranslatorMappings';
+
+const requirePackageJson = createRequire(__filename);
+const { version } = requirePackageJson('../../package.json') as { version: string };
 
 const knownWarFiles = translatorMappings.map((mapping) => mapping.warFile);
 const knownJsonFiles = translatorMappings.map((mapping) => mapping.jsonFile);


### PR DESCRIPTION
## Summary
- move `fs-extra` into runtime dependencies so production installs include it
- resolve the CLI version from the package root `package.json` instead of `dist/package.json`

Fixes #114.

## Verification
- Reproduced the published `wc3maptranslator@5.0.0` failure with a clean `npm install --omit=dev` followed by `wc3maptranslator --version`: it failed on missing `fs-extra`.
- `npm test` rebuilt successfully and ran 52/55 tests; the remaining 3 failures are existing binary round-trip assertions in `TranslatorReversion.test.js` unrelated to CLI startup.
- `npm pack --json --silent`
- Installed the generated tarball in a fresh temp project with `--omit=dev`; `./node_modules/.bin/wc3maptranslator --version` prints `5.0.0`.
- `npm ls fs-extra --all` shows `wc3maptranslator -> fs-extra@11.3.5`.

Note: `npm run lint` currently fails on pre-existing `no-explicit-any` errors in `src/CommonInterfaces.ts`; this PR does not touch that file.